### PR TITLE
Add PR workflow test scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The action does not run LLMs and does not call external tools. It only validates
 docs/
   agentic-pdlc-workflow.md
   github-issue-approval-workflow.md
+  pr-workflow-test-scenario.md
 ```
 
 ## Start

--- a/docs/pr-workflow-test-scenario.md
+++ b/docs/pr-workflow-test-scenario.md
@@ -1,0 +1,19 @@
+# PR Workflow Test Scenario
+
+## Purpose
+
+This scenario is a small change that can be used to test the AgentWorkflowPDLC pull request path without touching production code.
+
+## Test Steps
+
+1. Open a `PDLC Agent Task` issue.
+2. Fill the business context in Polish.
+3. Approve gates manually in the issue checklist up to `Planning approved`.
+4. Create a branch with a documentation-only change.
+5. Open a pull request using `.github/pull_request_template.md`.
+6. Confirm that GitHub Actions can run and that reviewers can link the PR back to the PDLC issue.
+
+## Expected Result
+
+The PR should demonstrate that the repository supports a manual approval workflow before coding, while still using normal GitHub pull request review for final changes.
+

--- a/sample-app/README.md
+++ b/sample-app/README.md
@@ -24,6 +24,8 @@ Recommended exercise:
 5. Open a PR against this sample app.
 6. Use `sample-app-ci.yml` as the deterministic gate.
 
+This README line intentionally lives under `sample-app/**` so documentation-only PRs can trigger the sample application CI during workflow tests.
+
 ## Local Commands
 
 ```powershell


### PR DESCRIPTION
## Summary
- Add a documentation-only scenario for testing the AgentWorkflowPDLC pull request path.
- Link the scenario from the repository structure in README.

## Test plan
- ReadLints returned no diagnostics for the changed markdown files.
- Reviewed the PR diff from `main...HEAD`.

Made with [Cursor](https://cursor.com)